### PR TITLE
Remove more specific whitelist

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,17 +1,6 @@
 <?xml version="1.0"?>
 <csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
     <policies>
-        <policy id="script-src-elem">
-            <values>
-                <value id="avarda-payment-widget-1" type="host">payment-widget.avarda.com</value>
-                <value id="avarda-payment-widget-2" type="host">*.payment-widget.avarda.com</value>
-                <value id="avarda-payment-widget-stage-1" type="host">payment-widget.stage.avarda.com</value>
-                <value id="avarda-payment-widget-stage-2" type="host">*.payment-widget.stage.avarda.com</value>
-                <value id="data-uri-scripts" type="host">data:</value>
-                <value id="self-host" type="host">'self'</value>
-            </values>
-        </policy>
-
         <policy id="script-src">
             <values>
                 <value id="avarda-payment-widget-1" type="host">payment-widget.avarda.com</value>


### PR DESCRIPTION
Magento does not automatically generate needed whitelisting for 'script-src-elem'. If no whitelist exists for 'script-src-elem', 'script-src' whitelist is used for these instead.